### PR TITLE
fix: pkg: Pinned version for nodejs & removed npm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euxo pipefail #exit in case of errors
 
 # install dependencies
@@ -11,7 +11,7 @@ while true; do
         echo -e "\xE2\x9D\x8C please input your password to proceed so that the setup runs successfully"
         echo
 
-        if type -p curl >/dev/null || (sudo apt update && sudo apt install -y curl ) && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && sudo apt update && sudo apt install gh -y && sudo apt install -y git nodejs npm; then
+        if type -p curl >/dev/null || (sudo apt update && sudo apt install -y curl ) && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt update && sudo apt install -y gh git nodejs; then
             echo
             break
         else


### PR DESCRIPTION
#16 
- Replaced shebang with bash
- Pinned node version to 20.x
- Removed installation for nodejs
  - reason: nodejs installation comes with npm out of the box and os installation could cause conflict dependencies.